### PR TITLE
fix: i18n fallback treats empty string as missing key

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1302,7 +1302,7 @@ input::placeholder {
     }
   };
 
-  function T(key) { return (i18n[currentLang] || i18n.en)[key] || (i18n.en)[key] || key; }
+  function T(key) { var v = (i18n[currentLang] || i18n.en)[key]; if (v !== undefined) return v; v = i18n.en[key]; return v !== undefined ? v : key; }
 
   function applyI18n() {
     document.querySelectorAll('[data-i18n]').forEach(function(el) {
@@ -2206,7 +2206,7 @@ body {
     }
   };
 
-  function T(key) { return (i18n[curLang] || i18n.en)[key] || key; }
+  function T(key) { var v = (i18n[curLang] || i18n.en)[key]; return v !== undefined ? v : key; }
 
   function applyStaticLabels() {
     document.querySelectorAll('[data-i18n]').forEach(function(el) {


### PR DESCRIPTION
The T() function uses || to fall back to the key name when a translation is missing. This treats empty string values (like English unitSuffix: '') as missing, so the literal key name shows up in the UI instead.

Fixed both T() functions to check !== undefined instead of ||.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation fallback logic in the dashboard to ensure consistent text display across supported languages when translations are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->