### PR TITLE
fix: charts render at wrong height on initial page load

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -2429,6 +2429,7 @@ body {
       document.getElementById('tgStatus').textContent = data.telegram_active ? 'ON' : 'OFF';
       document.getElementById('lastUpdate').textContent = new Date().toLocaleTimeString();
       fetchFailCount = 0;
+      if (!hasInitialResize) { hasInitialResize = true; rebuildCharts(); fetchData(); }
     }).catch(function(e) { console.error('Fetch error:', e); fetchFailCount++; });
   }
 
@@ -2436,6 +2437,7 @@ body {
   updateToggleButtons();
   initCharts();
 
+  var hasInitialResize = false;
   var fetchFailCount = 0;
   function fetchWithBackoff() {
     fetchData();


### PR DESCRIPTION
Charts are created before the first data fetch completes, so they get incorrect container dimensions and render shorter than expected. Clicking a game tab triggers a rebuild which fixes the height.

This rebuilds the charts once after the first successful data fetch so they pick up the correct size from the start.